### PR TITLE
Add Houkem AI data classification demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+venv/
+uploads/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+EXPOSE 5000
+CMD ["python", "-m", "houkem.app"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# DataClassify
+# Houkem
+
+Houkem is a simple AI‑powered data classification demo. Upload an Excel file and the system will attempt to classify each column according to Saudi PDPL, NDMO and global standards. The classification uses OpenRouter/Qwen when an API key is provided (via `OPENROUTER_API_KEY` environment variable); otherwise a basic heuristic is applied.
+
+## Features
+
+* Upload `.xlsx` files
+* Extract sample rows from each column
+* AI or heuristic classification into **Public**, **Internal**, **Confidential**, or **Top Secret**
+* Multilingual interface (English and Arabic)
+* Minimal Docker setup
+
+## Running locally
+
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+export OPENROUTER_API_KEY=your_key_here  # optional
+python -m houkem.app
+```
+
+Then open <http://localhost:5000>.
+
+## Docker
+
+```bash
+docker build -t houkem .
+docker run -p 5000:5000 -e OPENROUTER_API_KEY=your_key_here houkem
+```

--- a/houkem/__init__.py
+++ b/houkem/__init__.py
@@ -1,0 +1,1 @@
+"""Houkem package."""

--- a/houkem/app.py
+++ b/houkem/app.py
@@ -1,0 +1,48 @@
+import os
+from flask import Flask, request, render_template, redirect, url_for
+import pandas as pd
+from .classification import classify_column
+from .translations import TRANSLATIONS
+
+UPLOAD_FOLDER = "uploads"
+os.makedirs(UPLOAD_FOLDER, exist_ok=True)
+
+app = Flask(__name__)
+app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
+
+
+def get_text(lang: str, key: str) -> str:
+    return TRANSLATIONS.get(lang, TRANSLATIONS['en']).get(key, key)
+
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    lang = request.args.get('lang', 'en')
+    if request.method == 'POST':
+        file = request.files.get('file')
+        if not file:
+            return redirect(request.url)
+        filepath = os.path.join(app.config['UPLOAD_FOLDER'], file.filename)
+        file.save(filepath)
+        return redirect(url_for('results', filename=file.filename, lang=lang))
+    return render_template('index.html', text=get_text(lang, 'upload'), lang=lang, tr=TRANSLATIONS.get(lang, TRANSLATIONS['en']))
+
+
+@app.route('/results')
+def results():
+    lang = request.args.get('lang', 'en')
+    filename = request.args.get('filename')
+    if not filename:
+        return redirect(url_for('index'))
+    filepath = os.path.join(app.config['UPLOAD_FOLDER'], filename)
+    df = pd.read_excel(filepath)
+    classifications = []
+    for column in df.columns:
+        samples = df[column].dropna().astype(str).tolist()[:5]
+        classification = classify_column(column, samples)
+        classifications.append(classification)
+    return render_template('results.html', classifications=classifications, lang=lang, tr=TRANSLATIONS.get(lang, TRANSLATIONS['en']))
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/houkem/classification.py
+++ b/houkem/classification.py
@@ -1,0 +1,86 @@
+import os
+import re
+from typing import List, Dict, Any
+
+try:
+    import openai  # optional, used if OPENROUTER_API_KEY is provided
+except ImportError:  # if package not installed
+    openai = None
+
+
+PATTERNS = [
+    ("Top Secret", re.compile(r"(passport|national id|nid|ssn|iqama)", re.I)),
+    ("Confidential", re.compile(r"(email|e-mail|phone|address|credit|bank|health)", re.I)),
+    ("Internal", re.compile(r"(name|department|title)", re.I)),
+]
+
+
+class ColumnClassification:
+    def __init__(self, column: str, label: str, reason: str, source_name: str, source_type: str) -> None:
+        self.column = column
+        self.label = label
+        self.reason = reason
+        self.source_name = source_name
+        self.source_type = source_type
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "column": self.column,
+            "label": self.label,
+            "reason": self.reason,
+            "source_name": self.source_name,
+            "source_type": self.source_type,
+        }
+
+
+def heuristic_classify(column_name: str, samples: List[str]) -> ColumnClassification:
+    text = " ".join(str(s) for s in samples)
+    for label, pattern in PATTERNS:
+        if pattern.search(text):
+            reason = f"Matched pattern '{pattern.pattern}'"
+            return ColumnClassification(column_name, label, reason, column_name, "uploaded file")
+    return ColumnClassification(column_name, "Public", "No sensitive patterns detected", column_name, "uploaded file")
+
+
+def ai_classify(column_name: str, samples: List[str]) -> ColumnClassification:
+    api_key = os.getenv("OPENROUTER_API_KEY")
+    if not api_key or openai is None:
+        return heuristic_classify(column_name, samples)
+
+    openai.api_key = api_key
+    openai.base_url = "https://openrouter.ai/api/v1"
+
+    prompt = (
+        "You are a data classification assistant. "
+        "Classify the following column according to NDMO, Saudi PDPL, and global data standards. "
+        "Return one of: Public, Internal, Confidential, Top Secret. "
+        "Provide reasoning in one sentence."
+    )
+    user_content = f"Column: {column_name}\nSamples: {samples}"
+    messages = [
+        {"role": "system", "content": prompt},
+        {"role": "user", "content": user_content},
+    ]
+
+    try:
+        resp = openai.ChatCompletion.create(
+            model="qwen:Qwen1.5-72B-chat",
+            messages=messages,
+            temperature=0.2,
+        )
+        content = resp["choices"][0]["message"]["content"].strip()
+        # expecting label: reasoning
+        parts = content.split(":", 1)
+        if len(parts) == 2:
+            label, reason = parts[0].strip(), parts[1].strip()
+        else:
+            label, reason = content, ""
+        if label not in {"Public", "Internal", "Confidential", "Top Secret"}:
+            label = "Public"
+        return ColumnClassification(column_name, label, reason, column_name, "uploaded file")
+    except Exception as exc:
+        return ColumnClassification(column_name, "Public", f"AI error: {exc}", column_name, "uploaded file")
+
+
+def classify_column(column_name: str, samples: List[str]) -> ColumnClassification:
+    return ai_classify(column_name, samples)

--- a/houkem/translations.py
+++ b/houkem/translations.py
@@ -1,0 +1,22 @@
+TRANSLATIONS = {
+    'en': {
+        'title': 'Houkem - AI Data Classification',
+        'upload': 'Upload Excel File',
+        'submit': 'Submit',
+        'results': 'Classification Results',
+        'column': 'Column',
+        'label': 'Label',
+        'reason': 'Reason',
+        'source': 'Data Source',
+    },
+    'ar': {
+        'title': 'حوكم - تصنيف البيانات بالذكاء الاصطناعي',
+        'upload': 'تحميل ملف إكسل',
+        'submit': 'إرسال',
+        'results': 'نتائج التصنيف',
+        'column': 'العمود',
+        'label': 'التصنيف',
+        'reason': 'السبب',
+        'source': 'مصدر البيانات',
+    }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+flask
+pandas
+openpyxl
+openai

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,4 @@
+body { font-family: Arial, sans-serif; margin: 40px; }
+table { border-collapse: collapse; width: 100%; }
+th, td { border: 1px solid #ccc; padding: 8px; text-align: left; }
+th { background-color: #f0f0f0; }

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="{{ lang }}">
+  <head>
+    <meta charset="utf-8">
+    <title>{{ tr['title'] }}</title>
+    <link rel="stylesheet" href="/static/style.css">
+  </head>
+  <body>
+    <h1>{{ tr['title'] }}</h1>
+    <form method="post" enctype="multipart/form-data">
+      <input type="file" name="file" accept=".xlsx" required>
+      <button type="submit">{{ tr['submit'] }}</button>
+    </form>
+    <p>
+      <a href="?lang=en">English</a> | <a href="?lang=ar">العربية</a>
+    </p>
+  </body>
+</html>

--- a/templates/results.html
+++ b/templates/results.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="{{ lang }}">
+  <head>
+    <meta charset="utf-8">
+    <title>{{ tr['results'] }}</title>
+    <link rel="stylesheet" href="/static/style.css">
+  </head>
+  <body>
+    <h1>{{ tr['results'] }}</h1>
+    <table>
+      <tr>
+        <th>{{ tr['column'] }}</th>
+        <th>{{ tr['label'] }}</th>
+        <th>{{ tr['reason'] }}</th>
+        <th>{{ tr['source'] }}</th>
+      </tr>
+      {% for cls in classifications %}
+      <tr>
+        <td>{{ cls.column }}</td>
+        <td>{{ cls.label }}</td>
+        <td>{{ cls.reason }}</td>
+        <td>{{ cls.source_name }}</td>
+      </tr>
+      {% endfor %}
+    </table>
+    <p><a href="/">{{ tr['upload'] }}</a></p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple Flask application named **Houkem** with multilingual support
- implement heuristic/AI-based column classification
- add minimal UI templates and styling
- include Dockerfile and requirements for running
- document setup instructions in README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile houkem/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684329709b04832399482bcbf3c8db1c