### PR TITLE
Add FastAPI backend and Streamlit frontend

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,1 @@
+OPENROUTER_API_KEY=your_openrouter_api_key

--- a/README.md
+++ b/README.md
@@ -1,30 +1,36 @@
-# Houkem
+# Data Classify MVP
 
-Houkem is a simple AI‑powered data classification demo. Upload an Excel file and the system will attempt to classify each column according to Saudi PDPL, NDMO and global standards. The classification uses OpenRouter/Qwen when an API key is provided (via `OPENROUTER_API_KEY` environment variable); otherwise a basic heuristic is applied.
+This project provides a minimal backend and frontend for classifying columns in Excel files according to the Saudi NDMO and PDPL policies.
 
 ## Features
+* Upload `.xlsx` files via FastAPI
+* Sample the first five values from each column
+* Classify each column using OpenRouter (GPT‑4) with a Saudi‑specific prompt
+* Streamlit dashboard showing per‑column classifications and overall counts
+* Dockerized services with `docker-compose`
 
-* Upload `.xlsx` files
-* Extract sample rows from each column
-* AI or heuristic classification into **Public**, **Internal**, **Confidential**, or **Top Secret**
-* Multilingual interface (English and Arabic)
-* Minimal Docker setup
+## Quick Start
 
-## Running locally
+1. Copy `.env.sample` to `.env` and provide your OpenRouter API key.
+2. Build and run using docker-compose:
+
+```bash
+docker-compose up --build
+```
+
+Backend will be available at <http://localhost:8000> and Streamlit UI at <http://localhost:8501>.
+
+## Development
 
 ```bash
 python -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
-export OPENROUTER_API_KEY=your_key_here  # optional
-python -m houkem.app
+uvicorn backend.main:app --reload
 ```
 
-Then open <http://localhost:5000>.
-
-## Docker
+Then run Streamlit separately:
 
 ```bash
-docker build -t houkem .
-docker run -p 5000:5000 -e OPENROUTER_API_KEY=your_key_here houkem
+streamlit run frontend/streamlit_app.py
 ```

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY ../requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . /app/backend
+CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,100 @@
+import os
+import json
+import pandas as pd
+import requests
+from fastapi import FastAPI, UploadFile, File, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+
+PROMPT = (
+    "You are a senior data classification officer working for the Saudi National Data Management Office (NDMO). "
+    "Given a column name and a small sample of its values, your task is to classify the sensitivity and impact of this data based on both:\n"
+    "- The Saudi NDMO Data Classification Policy\n"
+    "- The Saudi Personal Data Protection Law (PDPL)\n\n"
+    "Classify each column into only one of the following Impact Levels:\n"
+    "- \ud83d\udd34 Top Secret: Highly sensitive data; unauthorized disclosure could threaten national security or cause severe damage to the Kingdom's strategic interests.\n"
+    "- \ud83d\udd36 Confidential: Sensitive data; unauthorized disclosure could cause significant harm to the state or organizations.\n"
+    "- \ud83d\dfe1 Restricted: Data requiring special protection; unauthorized disclosure does not pose a serious threat.\n"
+    "- \ud83d\udd35 Public: Data that can be shared with the public without restrictions.\n\n"
+    "Respond in the following JSON format only:\n"
+    "{\n  \"column\": \"ColumnName\",\n  \"classification\": \"Public | Restricted | Confidential | Top Secret\",\n  \"justification\": \"Short explanation for classification based on Saudi regulations.\"\n}"
+    "If in doubt, always choose the safer classification."
+)
+
+app = FastAPI(title="Data Classify API")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+PATTERNS = [
+    ("Top Secret", r"(passport|national id|nid|ssn|iqama)",),
+    ("Confidential", r"(email|e-mail|phone|mobile|address|credit|bank|health)",),
+    ("Restricted", r"(name|department|title)",),
+]
+
+
+def heuristic_classify(column: str, samples):
+    text = " ".join(samples)
+    for label, pattern in PATTERNS:
+        if re.search(pattern, text, re.I):
+            return {
+                "column": column,
+                "classification": label,
+                "justification": f"Matched pattern '{pattern}'"
+            }
+    return {"column": column, "classification": "Public", "justification": "No sensitive patterns detected"}
+
+
+import re
+
+def ai_classify(column: str, samples):
+    api_key = os.getenv("OPENROUTER_API_KEY")
+    if not api_key:
+        return heuristic_classify(column, samples)
+
+    url = "https://openrouter.ai/api/v1/chat/completions"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    messages = [
+        {"role": "system", "content": PROMPT},
+        {
+            "role": "user",
+            "content": f"Column name: {column}\nSample values: {samples}"
+        },
+    ]
+    payload = {
+        "model": "gpt-4",  # use gpt-4 via OpenRouter
+        "messages": messages,
+        "temperature": 0.2,
+    }
+    try:
+        resp = requests.post(url, headers=headers, json=payload, timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+        content = data["choices"][0]["message"]["content"]
+        return json.loads(content)
+    except Exception as exc:
+        return heuristic_classify(column, samples)
+
+
+@app.post("/upload")
+async def upload(file: UploadFile = File(...)):
+    if not file.filename.endswith(".xlsx"):
+        raise HTTPException(status_code=400, detail="Only .xlsx files are supported")
+    df = pd.read_excel(file.file)
+    results = []
+    for col in df.columns:
+        samples = df[col].dropna().astype(str).tolist()[:5]
+        classification = ai_classify(col, samples)
+        results.append(classification)
+    return {"results": results}
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3'
+services:
+  backend:
+    build: ./backend
+    ports:
+      - "8000:8000"
+    environment:
+      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
+  frontend:
+    build: ./frontend
+    ports:
+      - "8501:8501"
+    environment:
+      - BACKEND_URL=http://backend:8000/upload
+    depends_on:
+      - backend
+

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY ../requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . /app/frontend
+CMD ["streamlit", "run", "frontend/streamlit_app.py", "--server.port", "8501", "--server.address", "0.0.0.0"]

--- a/frontend/streamlit_app.py
+++ b/frontend/streamlit_app.py
@@ -1,0 +1,27 @@
+import os
+import pandas as pd
+import requests
+import streamlit as st
+
+API_URL = os.getenv("BACKEND_URL", "http://localhost:8000/upload")
+
+st.title("Data Classification Dashboard")
+
+uploaded_file = st.file_uploader("Upload Excel File", type="xlsx")
+
+if uploaded_file is not None:
+    with st.spinner("Classifying..."):
+        files = {"file": (uploaded_file.name, uploaded_file.getvalue(), "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")}
+        resp = requests.post(API_URL, files=files)
+        if resp.status_code != 200:
+            st.error(f"Error from API: {resp.text}")
+        else:
+            data = resp.json()["results"]
+            df = pd.DataFrame(data)
+            st.subheader("Results")
+            st.dataframe(df)
+
+            counts = df["classification"].value_counts()
+            st.subheader("Summary")
+            st.bar_chart(counts)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-flask
+fastapi
+uvicorn
+requests
 pandas
 openpyxl
-openai
+streamlit


### PR DESCRIPTION
## Summary
- switch requirements to FastAPI stack
- create FastAPI backend to classify Excel columns using OpenRouter
- add Streamlit dashboard frontend
- provide Dockerfiles, docker-compose, and sample env file
- update README with usage instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68444eb70bd883239149ff482c79b001